### PR TITLE
Update block-member-contact-form.css

### DIFF
--- a/assets/css/block-member-contact-form.css
+++ b/assets/css/block-member-contact-form.css
@@ -30,7 +30,13 @@
 }
 
 .reception-contact-form-modal {
-	width: 600px;
+    width: 100%;
+}
+
+@media (min-width: 1000px) {
+	.reception-contact-form-modal {   
+		width: 600px;
+	}
 }
 
 .reception-contact-form-modal .block-editor-rich-text__editable [data-rich-text-placeholder] {


### PR DESCRIPTION
Reception modal is partially cut off on devices like the iPhone. By making the form modal 100% width, that ensures it takes up the full mobile screen without being cut off. Then, we wrap the original 600px width in a media query for larger screens.